### PR TITLE
Downgrade Linq2DB to 4.4.1

### DIFF
--- a/src/Pechka.AspNet/Pechka.AspNet.csproj
+++ b/src/Pechka.AspNet/Pechka.AspNet.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="CommandLineParser" Version="2.8.0" />
         <PackageReference Include="CoreRpc.AspNetCore" Version="0.5.4" />
         <PackageReference Include="Nito.AsyncEx" Version="5.1.0" />
-        <PackageReference Include="linq2db.PostgreSQL" Version="5.0.0" />
+        <PackageReference Include="linq2db.PostgreSQL" Version="4.4.1" />
         <PackageReference Include="Serenity.FluentMigrator.Runner" Version="1.6.904" />
         <None Remove="$(NuGetPackageRoot)linq2db.postgresql/**/*.*" />
     </ItemGroup>


### PR DESCRIPTION
linq2db.postgres in 5.0.0 is broken, PostgreSQLTools.GetDataProvider assign ConnectionString to a ConfigurationString

![image](https://user-images.githubusercontent.com/3408281/225084118-a91faec8-7ef1-4bfc-ba2d-3e01a9249fd7.png)
