### PR TITLE
feature: Support Multiple Apps

### DIFF
--- a/src/Pechka.AspNet/Cmdlets/CmdletGenerateTsApi.cs
+++ b/src/Pechka.AspNet/Cmdlets/CmdletGenerateTsApi.cs
@@ -5,7 +5,6 @@ using CommandLine;
 
 namespace Pechka.AspNet.Cmdlets
 {
-    
     internal class CmdletGenerateTsApi : CmdletBase<CmdletGenerateTsApi.GenerateTsApiOptions>
     {
         private readonly RuntimeAppInfo _info;
@@ -24,12 +23,12 @@ namespace Pechka.AspNet.Cmdlets
 
         protected override int Execute(GenerateTsApiOptions args)
         {
-            var devJsRoot = Path.Combine(Directory.GetCurrentDirectory(), "Frontend/packages/corerpc-api");
-            if (!Directory.Exists(devJsRoot)) return -1;
-            
-            File.WriteAllText(Path.Combine(devJsRoot, "api.ts"), _interop.GenerateTsRpc());
+            var apits = Path.Combine(_info.Info.ContentRoot, _info.Config.WebAppApiPath);
+            var folder = Path.GetDirectoryName(apits);
+            if (!Directory.Exists(folder)) return -1;
+
+            File.WriteAllText(apits, _interop.GenerateTsRpc());
             Console.WriteLine("api.ts created!");
-            Environment.Exit(0);
             return 0;
         }
     }

--- a/src/Pechka.AspNet/PechkaConfiguration.cs
+++ b/src/Pechka.AspNet/PechkaConfiguration.cs
@@ -1,12 +1,18 @@
 using System;
+using System.Collections.Generic;
 using CoreRPC.Typescript;
 
 namespace Pechka.AspNet;
 
 public class PechkaConfiguration
 {
-    public string? WebAppRoot { get; set; }
-    public string? WebAppApiPath { get; set; }
-    public string? WebAppBuildPath { get; set; }
+    public string WebAppApiPath { get; set; }
+    public List<PechkaWebAppConfiguration> WebAppPaths { get; set; } = new();
     public Action<TypescriptGenerationOptions>? TypescriptGenerationOptions { get; set; }
+}
+
+public class PechkaWebAppConfiguration
+{
+    public string WebAppBuildPath { get; set; }
+    public string WebAppPrefix { get; set; } = string.Empty;
 }

--- a/src/Pechka.AspNet/PechkaConfiguration.cs
+++ b/src/Pechka.AspNet/PechkaConfiguration.cs
@@ -1,13 +1,23 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using CoreRPC.Typescript;
 
 namespace Pechka.AspNet;
 
 public class PechkaConfiguration
 {
-    public string WebAppApiPath { get; set; }
-    public List<PechkaWebAppConfiguration> WebAppPaths { get; set; } = new();
+    public string WebAppApiPath { get; set; } = Path.Combine("webapp", "src", "api.ts");
+
+    public List<PechkaWebAppConfiguration> WebAppPaths { get; set; } = new()
+    {
+        new PechkaWebAppConfiguration
+        {
+            WebAppPrefix = string.Empty,
+            WebAppBuildPath = Path.Combine("webapp", "build"),
+        },
+    };
+
     public Action<TypescriptGenerationOptions>? TypescriptGenerationOptions { get; set; }
 }
 

--- a/src/Pechka.AspNet/RuntimeAppInfo.cs
+++ b/src/Pechka.AspNet/RuntimeAppInfo.cs
@@ -1,5 +1,4 @@
 using System;
-using System.IO;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,18 +7,13 @@ namespace Pechka.AspNet;
 internal class RuntimeAppInfo
 {
     public RuntimeProgramInfo Info { get; }
+    public PechkaConfiguration Config { get; }
 
     public RuntimeAppInfo(IServiceProvider provider, RuntimeProgramInfo info)
     {
         Info = info;
         Config = provider.GetService<PechkaConfiguration>() ?? new PechkaConfiguration();
     }
-    
-    public PechkaConfiguration Config { get; }
-
-    public string GetWebAppRoot() => Path.Combine(Info.ContentRoot, Config.WebAppRoot ?? "webapp");
-    public string GetWebAppApiPath() => Path.Combine(GetWebAppRoot(), Config.WebAppApiPath ?? "src/api.ts");
-    public string GetWebAppBuildPath() => Path.Combine(GetWebAppRoot(), Config.WebAppBuildPath ?? "build");
 }
 
 internal class RuntimeProgramInfo


### PR DESCRIPTION
Now one can write the following code in order to configure Pechka:

```csharp
private static IPechkaProgramBuilderExecutable CreatePechkaBuilder(string[] args) =>
    PechkaProgramBuilder<Program>
        .Create(args)
        .ConfigureServices((config, services) =>
        {
            services.AddSingleton(new PechkaConfiguration
            {
                WebAppApiPath = "Frontend/packages/corerpc-api/api.ts",
                WebAppPaths = new List<PechkaWebAppConfiguration>
                {
                     new()
                     {
                         WebAppPrefix = string.Empty,
                         WebAppBuildPath = "Frontend/packages/web-app/build",
                     },
                     new()
                     {
                         WebAppPrefix = "/admin",
                         WebAppBuildPath = "Frontend/packages/admin-app/build",
                     }
                }
            });
```
