### PR TITLE
Fix embedded GenerateTsApi cmdlet

### DIFF
--- a/samples/MyWebApp/Program.cs
+++ b/samples/MyWebApp/Program.cs
@@ -4,6 +4,12 @@ using Pechka.AspNet;
 
 void ConfigureServices(IConfiguration configuration, IServiceCollection services)
 {
+    services.AddSingleton(new PechkaConfiguration()
+    {
+        WebAppRoot = "webapp",
+        WebAppApiPath = "webapp/src/api.ts",
+        WebAppBuildPath = "webapp/build"
+    });
     services.AddControllers();
     services.AddDbContextManager((dp, c) => new MyDbContextManager(dp, c));
 }

--- a/samples/MyWebApp/Program.cs
+++ b/samples/MyWebApp/Program.cs
@@ -7,8 +7,8 @@ void ConfigureServices(IConfiguration configuration, IServiceCollection services
     services.AddSingleton(new PechkaConfiguration()
     {
         WebAppRoot = "webapp",
-        WebAppApiPath = "webapp/src/api.ts",
-        WebAppBuildPath = "webapp/build"
+        WebAppApiPath = "src/api.ts",
+        WebAppBuildPath = "build"
     });
     services.AddControllers();
     services.AddDbContextManager((dp, c) => new MyDbContextManager(dp, c));

--- a/src/Pechka.AspNet/Cmdlets/CmdletGenerateTsApi.cs
+++ b/src/Pechka.AspNet/Cmdlets/CmdletGenerateTsApi.cs
@@ -25,7 +25,10 @@ namespace Pechka.AspNet.Cmdlets
         protected override int Execute(GenerateTsApiOptions args)
         {
             // NOTE: Maybe just throw exception here?
-            var apiPath = _info.Config.WebAppApiPath ?? "Frontend/packages/corerpc-api/api.ts";
+            var apiPath = _info.Config is { WebAppRoot: not null, WebAppApiPath: not null }
+                ? Path.Combine(_info.Config.WebAppRoot, _info.Config.WebAppApiPath)
+                : "Frontend/packages/corerpc-api/api.ts";
+            
             var devJsRoot = Path.Combine(Directory.GetCurrentDirectory(), apiPath);
             var targetDirectory = Path.GetDirectoryName(devJsRoot);
             

--- a/src/Pechka.AspNet/Cmdlets/CmdletGenerateTsApi.cs
+++ b/src/Pechka.AspNet/Cmdlets/CmdletGenerateTsApi.cs
@@ -24,12 +24,19 @@ namespace Pechka.AspNet.Cmdlets
 
         protected override int Execute(GenerateTsApiOptions args)
         {
-            var devJsRoot = Path.Combine(Directory.GetCurrentDirectory(), "Frontend/packages/corerpc-api");
-            if (!Directory.Exists(devJsRoot)) return -1;
+            // NOTE: Maybe just throw exception here?
+            var apiPath = _info.Config.WebAppApiPath ?? "Frontend/packages/corerpc-api/api.ts";
+            var devJsRoot = Path.Combine(Directory.GetCurrentDirectory(), apiPath);
+            var targetDirectory = Path.GetDirectoryName(devJsRoot);
             
-            File.WriteAllText(Path.Combine(devJsRoot, "api.ts"), _interop.GenerateTsRpc());
+            if (!Directory.Exists(targetDirectory))
+            {
+                Console.WriteLine($"Target directory {targetDirectory} doesn't exist! Check your PechkaConfiguration -> WebAppApiPath");
+                return 1;
+            }
+            
+            File.WriteAllText(Path.Combine(devJsRoot), _interop.GenerateTsRpc());
             Console.WriteLine("api.ts created!");
-            Environment.Exit(0);
             return 0;
         }
     }


### PR DESCRIPTION
GenerateTsApi was broken because Cmdlet doesn't respect PechkaConfiguration settings